### PR TITLE
Resolve unitialised size variable issue

### DIFF
--- a/lib/src/glitters.dart
+++ b/lib/src/glitters.dart
@@ -178,8 +178,8 @@ class _Paint extends StatefulWidget {
 class _PaintState extends State<_Paint> with SingleTickerProviderStateMixin {
   late final AnimationController _controller;
 
-  late double _size;
-  late Offset _offset;
+  double? _size;
+  Offset? _offset;
 
   var _status = _Status.notInitialized;
 
@@ -249,9 +249,9 @@ class _PaintState extends State<_Paint> with SingleTickerProviderStateMixin {
                   widget.constraints.maxHeight,
                 ),
                 painter: GlitterPainter(
-                  width: _size,
-                  height: _size,
-                  offset: _offset,
+                  width: _size ?? kDefaultSize,
+                  height: _size ?? kDefaultSize,
+                  offset: _offset ?? Offset.zero,
                   aspectRatio: 1.0,
                   color: widget.color,
                   opacity: opacity,
@@ -274,8 +274,8 @@ class _PaintState extends State<_Paint> with SingleTickerProviderStateMixin {
           widget.minSize;
 
       _offset = Offset(
-        Random().nextDouble() * (constraints.maxWidth - _size),
-        Random().nextDouble() * (constraints.maxHeight - _size),
+        Random().nextDouble() * (constraints.maxWidth - (_size ?? kDefaultSize)),
+        Random().nextDouble() * (constraints.maxHeight - (_size ?? kDefaultSize)),
       );
 
       _status = _Status.updated;


### PR DESCRIPTION
Occasionally, I found that during initialisation, the `size` variable would not be initalised. I changed the `_size` and `_offset` types to make them nullable, and also specified to use the default size if the value had not been set at the time of the glitters being rendered.