### PR TITLE
Ensure that a glitter with a delay is shown even if the delay is very small

### DIFF
--- a/lib/src/glitters.dart
+++ b/lib/src/glitters.dart
@@ -227,7 +227,8 @@ class _PaintState extends State<_Paint> with SingleTickerProviderStateMixin {
         final v = _controller.value;
         final t = v <= 1.0 - from ? v + from : v - (1.0 - from);
         final opacity = tween.transform(t);
-        _updateGlitter(widget.constraints, from, t);
+
+        _renewGlitterIfNecessary(widget.constraints, from, t);
 
         return _isReady
             ? CustomPaint(
@@ -249,7 +250,11 @@ class _PaintState extends State<_Paint> with SingleTickerProviderStateMixin {
     );
   }
 
-  void _updateGlitter(BoxConstraints constraints, double from, double t) {
+  void _renewGlitterIfNecessary(
+    BoxConstraints constraints,
+    double from,
+    double t,
+  ) {
     final isBeginningWithNoDelay = widget.delay == Duration.zero && t == 0.0;
     final isBeginning = t < _prevT;
     _prevT = t;

--- a/lib/src/glitters.dart
+++ b/lib/src/glitters.dart
@@ -7,7 +7,6 @@ import 'stack.dart';
 
 enum _Status {
   notInitialized,
-  initialized,
   updated,
 }
 
@@ -195,15 +194,7 @@ class _PaintState extends State<_Paint> with SingleTickerProviderStateMixin {
     super.initState();
 
     _controller = AnimationController(vsync: this, duration: _totalDuration)
-      ..addStatusListener((animationStatus) {
-        if (animationStatus == AnimationStatus.completed) {
-          if (_status == _Status.updated) {
-            _status = _Status.initialized;
-          }
-          _controller.forward(from: 0.0);
-        }
-      })
-      ..forward();
+      ..repeat();
   }
 
   @override
@@ -220,7 +211,7 @@ class _PaintState extends State<_Paint> with SingleTickerProviderStateMixin {
         ..stop()
         ..reset()
         ..duration = _totalDuration
-        ..forward();
+        ..repeat();
     }
   }
 

--- a/lib/src/glitters.dart
+++ b/lib/src/glitters.dart
@@ -5,11 +5,6 @@ import 'consts.dart';
 import 'painter.dart';
 import 'stack.dart';
 
-enum _Status {
-  notInitialized,
-  updated,
-}
-
 /// A widget that fades in and out glitter-like shapes one by one inside itself.
 ///
 /// The size of the widget itself is calculated using the constraints obtained
@@ -180,7 +175,7 @@ class _PaintState extends State<_Paint> with SingleTickerProviderStateMixin {
   late double _size;
   late Offset _offset;
 
-  var _status = _Status.notInitialized;
+  var _isReady = false;
   var _prevT = 0.0;
 
   Duration get _totalDuration =>
@@ -234,9 +229,8 @@ class _PaintState extends State<_Paint> with SingleTickerProviderStateMixin {
         final opacity = tween.transform(t);
         _updateGlitter(widget.constraints, from, t);
 
-        return _status == _Status.notInitialized
-            ? const SizedBox.shrink()
-            : CustomPaint(
+        return _isReady
+            ? CustomPaint(
                 size: Size(
                   widget.constraints.maxWidth,
                   widget.constraints.maxHeight,
@@ -249,7 +243,8 @@ class _PaintState extends State<_Paint> with SingleTickerProviderStateMixin {
                   color: widget.color,
                   opacity: opacity,
                 ),
-              );
+              )
+            : const SizedBox.shrink();
       },
     );
   }
@@ -268,7 +263,7 @@ class _PaintState extends State<_Paint> with SingleTickerProviderStateMixin {
         Random().nextDouble() * (constraints.maxHeight - _size),
       );
 
-      _status = _Status.updated;
+      _isReady = true;
     }
   }
 

--- a/lib/src/glitters.dart
+++ b/lib/src/glitters.dart
@@ -182,6 +182,7 @@ class _PaintState extends State<_Paint> with SingleTickerProviderStateMixin {
   late Offset _offset;
 
   var _status = _Status.notInitialized;
+  var _prevT = 0.0;
 
   Duration get _totalDuration =>
       widget.duration +
@@ -263,14 +264,11 @@ class _PaintState extends State<_Paint> with SingleTickerProviderStateMixin {
   }
 
   void _updateGlitter(BoxConstraints constraints, double from, double t) {
-    final hasNoDelay = widget.delay == Duration.zero;
-    final isBeginning = (hasNoDelay || t < from) && t >= 0.0;
+    final isBeginningWithNoDelay = widget.delay == Duration.zero && t == 0.0;
+    final isBeginning = t < _prevT;
+    _prevT = t;
 
-    final isFirstTimeWithNoDelay =
-        _status == _Status.notInitialized && hasNoDelay;
-    final needUpdate = _status != _Status.updated && isBeginning;
-
-    if (isFirstTimeWithNoDelay || needUpdate) {
+    if (isBeginningWithNoDelay || isBeginning) {
       _size = Random().nextDouble() * (widget.maxSize - widget.minSize) +
           widget.minSize;
 


### PR DESCRIPTION
Fixes #8.

### Without a delay

```
 |------------|----------|-------------|----------|
 : inDuration   duration   outDuration   interval :
 :  :                                             :
 A  A'                                            B
```

- A
    - Animation value: 0.0
    - `t`: 0.0
- A'
    - The first call to `_updateGlitter()` (renamed to `_renewGlitterIfNecessary()`) is probably at the point A, but after that, it may be called at a slightly later point than A.
- B
    - Animation value: 1.0
    - `t`: 1.0

### With a delay

e.g. `from` is 0.8 (the point A is at 80% of the total duration)

```
 |------------|----------|-------------|----------|
 : inDuration   duration   outDuration   interval
 :  :                         |-------------------|
 C  C'                        : delay (invisible) :
                              :                   :
                              A                   B
```

- A
    - Animation value: 0.0
    - `t`: 0.8
- B
    - Animation value: 0.2
    - `t`: 1.0
- C
    - Animation value: 0.2000..01
    - `t`: 0.000..01
- C'
    - `_updateGlitter()` (renamed to `_renewGlitterIfNecessary()`) may be called at a slightly later point than C.
- A
    - Animation value: 1.0
    - `t`: 0.8

This fix is regarding the point `C'` above. If the value of `from` is small, between `C` and `C'`, the condition used before this fix (`t < from`) was never satisfied.

https://github.com/kaboc/flutter_glitters/blob/65a419216bde5e4c6b1467b15df9d6573daa3d34/lib/src/glitters.dart#L258-L260

This is the related code after the fix. The conditions for `A` and `A'` were also simplified. The line 258 is for `A`/`A'` and 259 is for `C'`.